### PR TITLE
Use posix-compatible %m[...] instead of obsolete %a[...]

### DIFF
--- a/tools/serviceref.c
+++ b/tools/serviceref.c
@@ -209,7 +209,7 @@ int main(int argc, char* argv[]) {
 			continue;
 		}
 
-		if(sscanf(line, "%a[^:]:%d :%a[^:]:%a[^:] :%d :%a[^:]:%a[^:]:%a[^:]:%a[^:]:%d :%d :%d :%d ",
+		if(sscanf(line, "%m[^:]:%d :%m[^:]:%m[^:] :%d :%m[^:]:%m[^:]:%m[^:]:%m[^:]:%d :%d :%d :%d ",
 		          &name,
 		          &freq,
 		          &parameters,


### PR DESCRIPTION
Using %a[...] in Combination with `-D_GNU_SOURCE` is only possible for C89 and C++ < C++11 after this change in glibc: https://gitlab.com/freedesktop-sdk/mirrors/sourceware/glibc/-/commit/03992356e6fedc5a5e9d32df96c1a2c79ea28a8f

For the vdr itself this was changed back in version 2.1.3: https://projects.vdr-developer.org/git/vdr.git/tree/HISTORY#n8115