### PR TITLE
Added option to set VDR's EPGScanTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ You can change these directories to meet your requirements.
 | VDR_LOGLEVEL | 2 | 0 = no logging, 1 = errors only, 2 = errors and info, 3 = errors, info and debug |
 | VDR_UPDATECHANNELS | 5 | 0 = disables, 1 = channel names only, 2 = pids only, 3 = channels names and pids, 4 = add new channels, 5 = add new transponders |
 | VDR_DISEQC | 0 | 0 = DisEqC disabled | 1 = enabled |
+| VDR_EPGSCANTIMEOUT | 5 | The time (in hours) of user inactivity after which the DVB card in a single card system starts scanning channels to keep the EPG up-to-date. A value of '0' completely turns off scanning on both single and multiple card systems. 
 | TZ | Europe/Vienna | Timezone to use |
 
 ## Ports in use

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,6 +84,7 @@ ENV DVBAPI_ENABLE="0" \
     VDR_UPDATECHANNELS=3 \
     VDR_DISEQC=0 \
     VDR_EPGSCANTYPE=1 \
+    VDR_EPGSCANTIMEOUT=5 \
     TZ="Europe/Vienna"
 
 RUN apk update && apk add freetype fontconfig libintl libexecinfo \

--- a/docker/bin/runvdr.sh
+++ b/docker/bin/runvdr.sh
@@ -30,6 +30,11 @@ echo "UpdateChannels = ${VDR_UPDATECHANNELS}" >> ${CONFDIR}/setup.conf
 
 echo "EPGScanType = ${VDR_EPGSCANTYPE}" >> ${CONFDIR}/setup.conf
 
+# EPGScanTimeout
+
+echo "EPGScanTimeout = ${VDR_EPGSCANTIMEOUT}" >> ${CONFDIR}/setup.conf
+
+
 # DVBAPI configuration
 
 echo "dvbapi.LogLevel = 2" >> ${CONFDIR}/setup.conf

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -22,6 +22,7 @@ docker run \
     -e VDR_LOGLEVEL=3 \
     -e VDR_UPDATECHANNELS=3 \
     -e VDR_EPGSCANTYPE=1 \
+    -e VDR_EGSCANTIMEOUT=5 \
     -v $PWD/mounts/data:/data \
     -v $PWD/mounts/cache:/data/cache \
     -v $PWD/mounts/video:/video \


### PR DESCRIPTION
Hi @pipelka 

as I wanted to disable VDRs EPG Scan, I've added an option to set EPGScanTimeout in the setup.conf.
It might be useful also for other users, so would be cool, if you'd accept it and merge. :-)

Thanks!