### PR TITLE
Fix "make install-conf"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,8 @@ install-lib: $(SOFILE)
 	install -D $^ $(DESTDIR)$(LIBDIR)/$^.$(APIVERSION)
 
 install-conf:
-	install -Dm644 $(PLUGIN)/allowed_hosts.conf $(DESTDIR)$(CFGDIR)/allowed_hosts.conf
-	install -Dm644 $(PLUGIN)/$(PLUGIN).conf $(DESTDIR)$(CFGDIR)/$(PLUGIN).conf
+	install -Dm644 config/allowed_hosts.conf $(DESTDIR)$(CFGDIR)/allowed_hosts.conf
+	install -Dm644 config/$(PLUGIN).conf $(DESTDIR)$(CFGDIR)/$(PLUGIN).conf
 
 install: install-lib
 


### PR DESCRIPTION
In commit https://github.com/pipelka/vdr-plugin-robotv/commit/bec2ef1952db648dec424930fe8699c02bedffe0 the config files were moved from "robotv" to "config". In this process, the Makefile was not updated. So a "make install-conf" now always fails.

This pull request fixes the Makefile so "make install-conf" can be used again.