### PR TITLE
[cmake] allow build with cmake-4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8...3.10)
 project(robotv)
 
 set(PLUGIN "robotv")

--- a/src/demuxer/CMakeLists.txt
+++ b/src/demuxer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8...3.10)
 project(robotvdmx)
 
 # set C++11 for robotv


### PR DESCRIPTION
use min...max syntax to allow build with newer cmake. ref: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html

fixes #21 